### PR TITLE
Updated nokogiri-plist -> plist.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A script to convert iTerm2 themes to gnome-terminal themes that uses
 
 ##Usage
 
-    ./itermtogt.rb /path/to/iterm_scheme.itermcolors
+    ./convert.rb /path/to/iterm_scheme.itermcolors
 
 ##Example:
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,26 @@
+# iTerm2 to Gnome Terminal Theme Converter
+
+A script to convert iTerm2 themes to gnome-terminal themes that uses
+[plist](https://github.com/bleything/plist) to read the colorschemes.
+
+[More info.](http://www.sharms.org/blog/2012/08/24/using-iterm2-themes-with-gnome-terminal/)
+
+##Usage
+
+    ./itermtogt.rb /path/to/iterm_scheme.itermcolors
+
+##Example:
+
+    $ ./convert.rb ./idleToes.itermcolors 
+    # ./idleToes.itermcolors
+    gconftool-2 --set /apps/gnome-terminal/profiles/Default/foreground_color --type string "#FFFFFF"
+    gconftool-2 --set /apps/gnome-terminal/profiles/Default/background_color --type string "#323232"
+    gconftool-2 --set /apps/gnome-terminal/profiles/Default/bold_color --type string "#FFFFA9"
+    gconftool-2 --set /apps/gnome-terminal/profiles/Default/palette --type string "#323232:#D25252:#7FE173:#FFC66D:#4098FF:#F57FFF:#BED6FF:#EEEEEC:#535353:#F07070:#9DFF90:#FFE48B:#5EB7F7:#FF9DFF:#DCF4FF:#FFFFFF"
+
+
+Then, you can just paste those commands into a gnome terminal, and it will set
+your color scheme.
+
+##Dependencies
+Requires the [plist gem](https://github.com/bleything/plist).

--- a/convertor.rb
+++ b/convertor.rb
@@ -1,5 +1,6 @@
+#!/usr/bin/env ruby
 # https://github.com/caseyhoward/nokogiri-plist
-require 'nokogiri-plist'
+require 'plist'
 
 # /apps/gnome-terminal/profiles/Default
 #  -> background_color
@@ -8,56 +9,55 @@ require 'nokogiri-plist'
 #  -> palette
 
 def convert_to_key(real_color)
-	return "%02X" % (real_color * 255)
+  return "%02X" % (real_color * 255)
 end
 
 def gconf2_command(gconf_key, gconf_type, gconf_value)
-	return "gconftool-2 --set /apps/gnome-terminal/profiles/Default/#{gconf_key} --type #{gconf_type} \"#{gconf_value}\""
+  return "gconftool-2 --set /apps/gnome-terminal/profiles/Default/#{gconf_key} --type #{gconf_type} \"#{gconf_value}\""
 end
 
 def get_rgb(doc_hash)
-	red   = convert_to_key(doc_hash["Red Component"])
-	green = convert_to_key(doc_hash["Green Component"])
-	blue  = convert_to_key(doc_hash["Blue Component"])
+  red   = convert_to_key(doc_hash["Red Component"])
+  green = convert_to_key(doc_hash["Green Component"])
+  blue  = convert_to_key(doc_hash["Blue Component"])
 
-	return "##{red}#{green}#{blue}"
+  return "##{red}#{green}#{blue}"
 end
 
 ARGV.each do |iterm_theme|
-	f              = open(iterm_theme)
-	doc            = Nokogiri::PList(f)
-	keys_to_export = Hash.new
-	keys_to_export["palette"] = Array.new(16)
+  doc            = Plist::parse_xml(iterm_theme)
+  keys_to_export = Hash.new
+  keys_to_export["palette"] = Array.new(16)
 
-	doc.keys.each do |doc_key|
-		if doc_key =~ /Ansi \d+ Color/
-			slot  = doc_key.scan(/Ansi (\d+) Color/)[0][0].to_i
-			hex   = get_rgb(doc[doc_key])
-			keys_to_export["palette"][slot] = hex
-		end
+  doc.keys.each do |doc_key|
+      if doc_key =~ /Ansi \d+ Color/
+          slot  = doc_key.scan(/Ansi (\d+) Color/)[0][0].to_i
+          hex   = get_rgb(doc[doc_key])
+          keys_to_export["palette"][slot] = hex
+      end
 
-		if doc_key =~ /Background Color/
-			# This goes directly to background_color
-			hex   = get_rgb(doc[doc_key])
-			keys_to_export["background_color"] = hex
-		end
+      if doc_key =~ /Background Color/
+          # This goes directly to background_color
+          hex   = get_rgb(doc[doc_key])
+          keys_to_export["background_color"] = hex
+      end
 
-		if doc_key =~ /Foreground Color/
-			# This goes directly to foreground_color
-			hex   = get_rgb(doc[doc_key])
-			keys_to_export["foreground_color"] = hex
-		end
+      if doc_key =~ /Foreground Color/
+          # This goes directly to foreground_color
+          hex   = get_rgb(doc[doc_key])
+          keys_to_export["foreground_color"] = hex
+      end
 
-		if doc_key =~ /Bold Color/
-			# This goes directly to bold color
-			hex   = get_rgb(doc[doc_key])
-			keys_to_export["bold_color"] = hex
-		end
-	end
+      if doc_key =~ /Bold Color/
+          # This goes directly to bold color
+          hex   = get_rgb(doc[doc_key])
+          keys_to_export["bold_color"] = hex
+      end
+  end
 
-	puts "# " + iterm_theme
-	puts gconf2_command("foreground_color", "string", keys_to_export["foreground_color"])
-	puts gconf2_command("background_color", "string", keys_to_export["background_color"])
-	puts gconf2_command("bold_color", "string", keys_to_export["bold_color"])
-	puts gconf2_command("palette", "string", keys_to_export["palette"].join(':'))
+  puts "# " + iterm_theme
+  puts gconf2_command("foreground_color", "string", keys_to_export["foreground_color"])
+  puts gconf2_command("background_color", "string", keys_to_export["background_color"])
+  puts gconf2_command("bold_color", "string", keys_to_export["bold_color"])
+  puts gconf2_command("palette", "string", keys_to_export["palette"].join(':'))
 end


### PR DESCRIPTION
nokogiri-plist doesn't appear to want to play nicely under ruby 1.9.3. Luckily, the api is almost identical to the more well known plist gem: https://rubygems.org/gems/plist

I also converted all of the tabs to the more accepted ruby style of two spaces per indentation level. Well, my editor did, anyway.

Also added a readme.
